### PR TITLE
remove redundant create_tap_dev, which is handled by libvirt [cherry-pick]

### DIFF
--- a/os_vif_bigswitch/vif_plug_ivs/ivs.py
+++ b/os_vif_bigswitch/vif_plug_ivs/ivs.py
@@ -67,7 +67,6 @@ class IvsPlugin(plugin.PluginBase):
 
     def _plug_ivs_ethernet(self, vif, instance):
         dev = self.get_vif_devname(vif)
-        linux_net.create_tap_dev(dev)
         linux_net.create_ivs_vif_port(dev)
 
     def _plug_ivs_hybrid(self, vif, instance):

--- a/os_vif_bigswitch/vif_plug_ivs/linux_net.py
+++ b/os_vif_bigswitch/vif_plug_ivs/linux_net.py
@@ -59,23 +59,6 @@ def device_exists(device):
     return os.path.exists('/sys/class/net/%s' % device)
 
 
-@privsep.vif_plug.entrypoint
-def create_tap_dev(dev, mac_address=None):
-    if not device_exists(dev):
-        try:
-            # First, try with 'ip'
-            processutils.execute('ip', 'tuntap', 'add', dev, 'mode', 'tap',
-                                 check_exit_code=[0, 2, 254])
-        except processutils.ProcessExecutionError:
-            # Second option: tunctl
-            processutils.execute('tunctl', '-b', '-t', dev)
-        if mac_address:
-            processutils.execute('ip', 'link', 'set', dev, 'address',
-                                 mac_address, check_exit_code=[0, 2, 254])
-        processutils.execute('ip', 'link', 'set', dev, 'up',
-                             check_exit_code=[0, 2, 254])
-
-
 def _delete_net_dev(dev):
     """Delete a network device only if it exists."""
     if device_exists(dev):


### PR DESCRIPTION
Reviewer: @sarath-kumar 

just cherry-picking to stable branch so i can bump the version

 - this was a common issue with all vendor os-vif plugins
 - upstream fixed and sent a mail downstream
 - for libvirt > 1.3.3, it does the right thing and creates
   appropriate tap dev
 - this function was required when that was not the case
 - having this causes issues when creating a TAP with multiqueue